### PR TITLE
Problem with parsing multiline comments

### DIFF
--- a/jsmin.c
+++ b/jsmin.c
@@ -110,7 +110,7 @@ next()
             break;
         case '*':
             get();
-            for (;;) {
+            while (c != ' ') {
                 switch (get()) {
                 case '*':
                     if (peek() == '/') {


### PR DESCRIPTION
Bugfix for multilne comments . It will never break the loop, because break is inside switch/case statement. So after first /\* it will consume file until EOF. 
